### PR TITLE
Lower docker-compose version requirement

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,4 +1,4 @@
-version: '3.9'
+version: '2'
 
 services:
   presence:


### PR DESCRIPTION
There is no need to set docker-compose.yaml's version requirement to bleeding edge 3.9. My setup is compatible up to 3.7 but no special features are used at all.